### PR TITLE
Correct equation Radiation Atmosphere

### DIFF
--- a/src/functions/radiationAtmosphere.js
+++ b/src/functions/radiationAtmosphere.js
@@ -4,7 +4,6 @@ export function radiationAtmosphere(relativeEarthSun, latitude, decSolar, sunris
   let radiationAtmosphere
 
   radiationAtmosphere = (37.586 * relativeEarthSun * (sunriseAngle * Math.sin(latitude) * Math.sin(decSolar) + Math.cos(latitude) * Math.cos(decSolar) * Math.sin(sunriseAngle)))
-  radiationAtmosphere = (radiationAtmosphere / 2.45)
-
+  
   return radiationAtmosphere
 }


### PR DESCRIPTION
This line should not exist: "radiationAtmosphere = (radiationAtmosphere / 2.45)"